### PR TITLE
stest: bugfix: an invalid argument "-allow-exec".

### DIFF
--- a/stest/common.py
+++ b/stest/common.py
@@ -127,7 +127,8 @@ def startup(s, useRepeater=False, rateMbps=0, delayMsec=0, wait=True):
     make_dir(workDir + s.name)
     args = get_server_args(s, sLayout, isDebug=isDebug, useRepeater=useRepeater,
                            maxFgTasks=maxFgTasks, maxBgTasks=maxBgTasks)
-    args.append('-allow-exec')
+    if s.kind == K_STORAGE:
+        args.append('-allow-exec')
     if s.kind == K_ARCHIVE and archiveDiscardMode is not None:
         args += ['-discard', archiveDiscardMode]
     if isDebug:


### PR DESCRIPTION
stest/common.pyのstartup関数はwalb-archive・walb-proxy・walb-storageの起動時、
オプションに"-allow-exec"を追加します。
しかし、バージョン1.0.7現在のwalb-archive・walb-proxyに"-allow-exec"オプションは
無くなっており、startup関数で起動後、"OptionError:bad opt"で終了してしまいます。

"-allow-exec"オプションは、walb-storageにのみ追加するよう
stest/common.pyのstartup関数を修正してみましたので、
差し支えなければ、マージをお願いいたします。

パッチは以下の1つのみです。
- bd97590 stest: bugfix: an invalid argument "-allow-exec".

以上です。
よろしくお願いいたします。